### PR TITLE
Remove a stray one from the start of every date

### DIFF
--- a/site.hs
+++ b/site.hs
@@ -7,7 +7,7 @@ import Hakyll
 
 
 timeFormat :: String
-timeFormat = "1%Y-%m-%d at %H:%M UTC"
+timeFormat = "%Y-%m-%d at %H:%M UTC"
 dateFormat :: String
 dateFormat = "%B %e, %Y"
 -------------------------------------------------------------------------------


### PR DESCRIPTION
I was browsing through your blog and noticed that the dates were all showing up with an extra `1` in front of every year. I though that this seemed to be a bit out of the ordinary, you couldn't be posting this from 10,000 years into the future, could you? (Are you? ⏲ 😸 )

This PR removes the extra `1` from the date format string.

